### PR TITLE
Fixed problem with midi.write_Track() crashing

### DIFF
--- a/mingus/midi/midi_track.py
+++ b/mingus/midi/midi_track.py
@@ -28,7 +28,7 @@ from binascii import a2b_hex
 from struct import pack, unpack
 from math import log
 from midi_events import *
-from mingus.core.keys import major_keys, minor_keys
+from mingus.core.keys import Key, major_keys, minor_keys
 from mingus.containers.note import Note
 
 class MidiTrack(object):
@@ -241,13 +241,13 @@ class MidiTrack(object):
 
     def set_key(self, key='C'):
         """Add a key signature event to the track_data."""
-        if isinstance(key, Note):
-            key = key.name
+        if isinstance(key, Key):
+            key = key.name[0]
         self.track_data += self.key_signature_event(key)
 
     def key_signature_event(self, key='C'):
         """Return the bytes for a key signature event."""
-        if key[0].islower():
+        if key.islower():
             val = minor_keys.index(key) - 7
             mode = '\x01'
         else:


### PR DESCRIPTION
First of all - what a fantastic library! I've just started using it and tried to call write_Track() with pretty much vanilla settings for Bars and Track and it was crashing due to some type mismatch. I'm not 100% sure if it doesn't break any other use scenarios and will keep testing. Thanks!