### PR TITLE
Adding channel and velocity as explicit class members and adding thei…

### DIFF
--- a/mingus/containers/note.py
+++ b/mingus/containers/note.py
@@ -41,6 +41,8 @@ class Note(object):
     name = 'C'
     octave = 4
     dynamics = {}
+    channel = 1
+    velocity = 64
 
     def __init__(self, name='C', octave=4, dynamics={}):
         if type(name) == str:
@@ -58,6 +60,13 @@ class Note(object):
             raise NoteFormatError("Don't know what to do with name object: "
                     "'%s'" % name)
 
+    
+    def set_channel(self, channel):
+        self.channel = channel
+        
+    def set_velocity(self, velocity):
+        self.velocity = velocity
+    
     def set_note(self, name='C', octave=4, dynamics={}):
         """Set the note to name in octave with dynamics.
 


### PR DESCRIPTION
…r setters

At the moment the only way to set channel and velocity for a Note is through class constructor. But the constructor calls for a 'name' object including those items. I've tried to conform to this format but I'm getting error when trying to supply conforming object. So it turned out the only way to actually set the channel for a Note was by adding members and accessors for conveniency. The solution works for me in the app where I need to split Notes to different channels. The change seems simple and most likely harmless and shouldn't create any side effects.