### PR TITLE
Added ability to set instrument_nr and set instrument name based on G…

### DIFF
--- a/mingus/containers/instrument.py
+++ b/mingus/containers/instrument.py
@@ -251,8 +251,12 @@ class MidiInstrument(Instrument):
         'Gunshot',
         ]
 
-    def __init__(self, name=''):
-        self.name = name
+    def __init__(self, instrument_nr=1):
+        self.instrument_nr = instrument_nr
+        try:
+            self.name = self.names[instrument_nr -1]
+        except IndexError:
+            self.name = 'Unknown Instrument'
 
 class MidiPercussionInstrument(Instrument):
     def __init__(self):


### PR DESCRIPTION
…M instr no.

I didn't seem to be possible to set instrument_nr. It was hardcoded as 1 and setting it as per docs didn't work. Also the list of instrument names didn't seem to be utilized so I propose changing the constructor argument from name to instrument_nr and then the name is being auto-set based on id using the GM list. Not really sure how to handle out of range numbers here (are they allowed by midi standard ect) so just setting 'Unknown Instrument' as name