### PR TITLE
General MIDI percussion support on sequencers

### DIFF
--- a/mingus/midi/fluidsynth.py
+++ b/mingus/midi/fluidsynth.py
@@ -208,4 +208,3 @@ def main_volume(channel, value):
 
 def set_instrument(channel, instr, bank=0):
     return midi.set_instrument(channel, instr, bank)
-

--- a/mingus/midi/sequencer.py
+++ b/mingus/midi/sequencer.py
@@ -112,7 +112,7 @@ class Sequencer(object):
         """Set the channel to the instrument _instr_."""
         if bank is None:
             if self.is_general_midi:
-                bank = 0 if channel != 9 else 1
+                bank = 0 if channel != 9 else 128
             else:
                 bank=0
         self.instr_event(channel, instr, bank)
@@ -331,7 +331,7 @@ class Sequencer(object):
                     i = 1
                 self.set_instrument(channels[x], i)
             elif isinstance(instr, MidiPercussionInstrument):
-                self.set_instrument(channels[x], 128)
+                self.set_instrument(channels[x], 0)
             else:
                 self.set_instrument(channels[x], 1)
         current_bar = 0
@@ -369,4 +369,3 @@ class Sequencer(object):
     def pan(self, channel, value):
         """Set the panning."""
         return self.control_change(channel, 10, value)
-


### PR DESCRIPTION
In GM standard MIDI files, channel 10 is reserved for percussion instruments only. I tried doing that using mingus's fluidsynth wrapper, but it wasn't working. The following code made it work, at least on fluidsynth, and it has backward compatibility, as it assumes the user is not using General MIDI.

References: 
- https://en.wikipedia.org/wiki/General_MIDI#Percussion
- http://stackoverflow.com/questions/23564706/no-preset-found-on-channel-9-when-playing-midi-with-newly-created-soundfont
