### PR TITLE
fix import error

### DIFF
--- a/mingus/core/notes.py
+++ b/mingus/core/notes.py
@@ -26,7 +26,7 @@ It handles conversions from integers to notes and vice versa and thus
 enables simple calculations.
 """
 
-from mt_exceptions import NoteFormatError, RangeError, FormatError
+from .mt_exceptions import NoteFormatError, RangeError, FormatError
 
 _note_dict = {
     'C': 0,


### PR DESCRIPTION
fixes import error when performing step one of tutorial "import mingus.core.notes as notes". When the import is attempted, error is raised "ImportError: No module named 'mt_exceptions'"