### PR TITLE
Delete 'channel' and 'velocity' attributes of 'Note' class.

### DIFF
--- a/mingus/containers/note.py
+++ b/mingus/containers/note.py
@@ -44,8 +44,6 @@ class Note(object):
     name = "C"
     octave = 4
     dynamics = {}
-    channel = 1
-    velocity = 64
 
     def __init__(self, name="C", octave=4, dynamics=None):
         if dynamics is None:


### PR DESCRIPTION
In the function "play_Note" of class "Sequencer" :
```
    def play_Note(self, note, channel=1, velocity=100):
        if hasattr(note, "velocity"):
            velocity = note.velocity
        if hasattr(note, "channel"):
            channel = note.channel
```
The code checks "velocity" and "channel" attributes. In original code the "Note" class has these two attributes in default, so above two condition clauses will pass any time, making you unable to control which channel to play through the function parameter. Deleting these two attributes makes them only exist after calling "Note.set_channel" method.