### PR TITLE
Fix transpose on Bar for rests

### DIFF
--- a/mingus/containers/bar.py
+++ b/mingus/containers/bar.py
@@ -24,7 +24,7 @@ from mingus.containers.mt_exceptions import MeterFormatError
 from mingus.containers.note_container import NoteContainer
 from mingus.core import meter as _meter
 from mingus.core import progressions, keys
-
+from typing import Optional
 
 class Bar(object):
     """A bar object.
@@ -117,6 +117,13 @@ class Bar(object):
         """
         return self.place_notes(None, duration)
 
+    def _is_note(self, note: Optional[NoteContainer]) -> bool:
+        """
+        Return whether the 'note' contained in a bar position is an actual NoteContainer.
+        If False, it is a rest (currently represented by None).
+        """
+        return isinstance(note, NoteContainer)
+
     def remove_last_entry(self):
         """Remove the last NoteContainer in the Bar."""
         self.current_beat -= 1.0 / self.bar[-1][1]
@@ -169,13 +176,13 @@ class Bar(object):
     def augment(self):
         """Augment the NoteContainers in Bar."""
         for cont in self.bar:
-            if cont[2]:
+            if self._is_note(cont[2]):
                 cont[2].augment()
 
     def diminish(self):
         """Diminish the NoteContainers in Bar."""
         for cont in self.bar:
-            if cont[2]:
+            if self._is_note(cont[2]):
                 cont[2].diminish()
 
     def transpose(self, interval, up=True):
@@ -184,7 +191,7 @@ class Bar(object):
         Call transpose() on all NoteContainers in the bar.
         """
         for cont in self.bar:
-            if cont[2]:
+            if self._is_note(cont[2]):
                 cont[2].transpose(interval, up)
 
     def determine_chords(self, shorthand=False):

--- a/mingus/containers/bar.py
+++ b/mingus/containers/bar.py
@@ -169,12 +169,14 @@ class Bar(object):
     def augment(self):
         """Augment the NoteContainers in Bar."""
         for cont in self.bar:
-            cont[2].augment()
+            if cont[2]:
+                cont[2].augment()
 
     def diminish(self):
         """Diminish the NoteContainers in Bar."""
         for cont in self.bar:
-            cont[2].diminish()
+            if cont[2]:
+                cont[2].diminish()
 
     def transpose(self, interval, up=True):
         """Transpose the notes in the bar up or down the interval.
@@ -182,7 +184,8 @@ class Bar(object):
         Call transpose() on all NoteContainers in the bar.
         """
         for cont in self.bar:
-            cont[2].transpose(interval, up)
+            if cont[2]:
+                cont[2].transpose(interval, up)
 
     def determine_chords(self, shorthand=False):
         """Return a list of lists [place_in_beat, possible_chords]."""

--- a/tests/unit/containers/test_bar.py
+++ b/tests/unit/containers/test_bar.py
@@ -79,6 +79,16 @@ class test_Bar(unittest.TestCase):
         b.transpose("3")
         self.assertEqual(b, c)
 
+    def test_transpose_rest(self):
+        b = Bar()
+        b.place_notes('C-4', 4)
+        b.place_rest(4)
+        c = Bar()
+        c.place_notes('E-4', 4)
+        c.place_rest(4)
+        b.transpose("3", True)
+        self.assertEqual(b, c)
+
     def test_augment(self):
         b = Bar()
         c = Bar()
@@ -93,11 +103,31 @@ class test_Bar(unittest.TestCase):
         c.augment()
         self.assertEqual(c, d)
 
+    def test_augment_rest(self):
+        b = Bar()
+        b.place_notes('C-4', 4)
+        b.place_rest(4)
+        c = Bar()
+        c.place_notes('C#-4', 4)
+        c.place_rest(4)
+        b.augment()
+        self.assertEqual(b, c)
+
     def test_diminish(self):
         b = Bar()
         c = Bar()
         b + "A"
         c + "Ab"
+        b.diminish()
+        self.assertEqual(b, c)
+
+    def test_diminish_rest(self):
+        b = Bar()
+        b.place_notes('C#-4', 4)
+        b.place_rest(4)
+        c = Bar()
+        c.place_notes('C-4', 4)
+        c.place_rest(4)
         b.diminish()
         self.assertEqual(b, c)
 


### PR DESCRIPTION
This skips rests when calling transpose(), augment() or diminish() on Bar. This previously caused an error for bars containing rests.