### PR TITLE
Fix bug that caused bars, tracks to be played to channel 1

### DIFF
--- a/mingus/midi/sequencer.py
+++ b/mingus/midi/sequencer.py
@@ -139,9 +139,9 @@ class Sequencer(object):
         you can set the Note.velocity and Note.channel attributes, which
         will take presedence over the function arguments.
         """
-        if hasattr(note, "velocity"):
+        if "velocity" in note.__dict__:
             velocity = note.velocity
-        if hasattr(note, "channel"):
+        if "channel" in note.__dict__:
             channel = note.channel
         self.play_event(int(note) + 12, int(channel), int(velocity))
         self.notify_listeners(

--- a/mingus/midi/sequencer.py
+++ b/mingus/midi/sequencer.py
@@ -151,10 +151,11 @@ class Sequencer(object):
         you can set the Note.velocity and Note.channel attributes, which
         will take presedence over the function arguments.
         """
-        if "velocity" in note.__dict__:
-            velocity = note.velocity
-        if "channel" in note.__dict__:
-            channel = note.channel
+        if hasattr(note, '__dict__'):
+            if "velocity" in note.__dict__:
+                velocity = note.velocity
+            if "channel" in note.__dict__:
+                channel = note.channel
         self.play_event(int(note) + 12, int(channel), int(velocity))
         self.notify_listeners(
             self.MSG_PLAY_INT,
@@ -176,7 +177,7 @@ class Sequencer(object):
         If Note.channel is set, it will take presedence over the channel
         argument given here.
         """
-        if hasattr(note, "channel"):
+        if hasattr(note, '__dict__') and "channel" in note.__dict__:
             channel = note.channel
         self.stop_event(int(note) + 12, int(channel))
         self.notify_listeners(self.MSG_STOP_INT, {"channel": int(channel), "note": int(note) + 12})

--- a/mingus/midi/sequencer.py
+++ b/mingus/midi/sequencer.py
@@ -344,7 +344,7 @@ class Sequencer(object):
             instr = tracks[x].instrument
             if instr is not None:
                 self.set_instrument(channels[x], instr)
-            current_bar = 0
+        current_bar = 0
         max_bar = len(tracks[0])
 
         # Play the bars


### PR DESCRIPTION
- fix bug in function play_Note that was making all notes to be played on channel 1 when channel was not set in Note object, ignoring erroneously channel parameter in play_NoteContainer, play_Bar, play_Bars, play_Tracks, ....
The following code was not working
```
fluidsynth.set_instrument(2, 34, 0)
fluidsynth.play_Track(t, 2)
```

- fix similar bug with velocity paramater in function  play_Note that was ignoring erroneously veolcity parameter 

- Fix bug that caused all tracks to play with instrument 1 when track.instrument is not set.
The following code was not working
```
fluidsynth.set_instrument(1, 34, 0)
fluidsynth.set_instrument(2, 15, 0)
fluidsynth.play_Tracks((t, t), (1, 2))
```
- Fix bug that caused track to play with wrong instrument, ignoring erroneously  track.instrument.
- The following code was not working
```
t = Track(MidiInstrument ("Rock Organ"))
fluidsynth.play_Track(t)
```

- Add possibilty to pass a string or a MidiInstrument to set_instrument. 
```
fluidsynth.set_instrument(1, "Rock Organ", 0)
fluidsynth.set_instrument(1, MidiInstrument ("Rock Organ"), 0)
```