### PR TITLE
Issue #98: chords.vii7(key) returns subtonic(key)

### DIFF
--- a/mingus/core/chords.py
+++ b/mingus/core/chords.py
@@ -756,7 +756,7 @@ def VII(key):
 
 
 def vii7(key):
-    return subtonic(key)
+    return subtonic7(key)
 
 
 def VII7(key):


### PR DESCRIPTION
Fixes [Issue #98](https://github.com/bspaans/python-mingus/issues/98): chords.vii7(key) returns subtonic(key) but should return subtonic7(key)