### PR TITLE
Do not omit velocity and channel arguments.

### DIFF
--- a/mingus/midi/sequencer.py
+++ b/mingus/midi/sequencer.py
@@ -139,9 +139,9 @@ class Sequencer(object):
         you can set the Note.velocity and Note.channel attributes, which
         will take presedence over the function arguments.
         """
-        if hasattr(note, "velocity"):
+        if hasattr(note, "velocity") and velocity == None:
             velocity = note.velocity
-        if hasattr(note, "channel"):
+        if hasattr(note, "channel") and channel == None:
             channel = note.channel
         self.play_event(int(note) + 12, int(channel), int(velocity))
         self.notify_listeners(


### PR DESCRIPTION
Note object has a default velocity/channel, therefore play_Note() cannot validate velocity/channel that are given as arguments.

Previously mentioned by these authors: #21 #22  #83 