### PR TITLE
Fix typo in tutorialMeter.html

### DIFF
--- a/doc/wiki/tutorialMeter.rst
+++ b/doc/wiki/tutorialMeter.rst
@@ -205,7 +205,7 @@ False
 Asymmetrical Meters
 -------------------
 
-Asymmetrical meters represent meters that can't be divided into parts of two. is_asymmetrical test whether this is true or not.
+Asymmetrical meters represent meters that can't be divided into parts of two. ``is_asymmetrical`` tests whether this is true or not.
 
 
 

--- a/doc/wiki/tutorialMeter.rst
+++ b/doc/wiki/tutorialMeter.rst
@@ -205,19 +205,19 @@ False
 Asymmetrical Meters
 -------------------
 
-Asymmetrical meters represent meters that can't be divided into parts of two. is_assymetrical test whether this is true or not.
+Asymmetrical meters represent meters that can't be divided into parts of two. is_asymmetrical test whether this is true or not.
 
 
 
->>> meter.is_assymetrical((3, 4))
+>>> meter.is_asymmetrical((3, 4))
 True
->>> meter.is_assymetrical((5, 4))
+>>> meter.is_asymmetrical((5, 4))
 True
->>> meter.is_assymetrical((7, 4))
+>>> meter.is_asymmetrical((7, 4))
 True
->>> meter.is_assymetrical((4, 4))
+>>> meter.is_asymmetrical((4, 4))
 False
->>> meter.is_assymetrical((6, 4))
+>>> meter.is_asymmetrical((6, 4))
 False
 
 


### PR DESCRIPTION
The `is_asymmetrical` function was misspelled consistently as `is_assymetrical` in the documentation which threw me for a bit of a loop, so this is a quick minor PR to correct that.